### PR TITLE
Jpa mapping/sync column names

### DIFF
--- a/src/main/java/com/cs544/project/domain/CourseOffering.java
+++ b/src/main/java/com/cs544/project/domain/CourseOffering.java
@@ -14,9 +14,11 @@ public class CourseOffering {
 
     private int capacity;
     private float credits;
-    @Enumerated(EnumType.STRING)
-    private CourseOfferingType courseOfferingType;
     private String room;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name="CourseOfferingType")
+    private CourseOfferingType courseOfferingType;
 
     @ManyToOne
     @JoinColumn(name = "FacultyID")

--- a/src/main/java/com/cs544/project/domain/CourseRegistration.java
+++ b/src/main/java/com/cs544/project/domain/CourseRegistration.java
@@ -7,7 +7,7 @@ import lombok.Data;
 @Entity
 public class CourseRegistration {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
     @ManyToOne
@@ -18,7 +18,8 @@ public class CourseRegistration {
     @JoinColumn(name = "CourseOfferingId")
     private CourseOffering courseOffering;
 
-    @OrderColumn(name="Sequence")
-    @Column(name="Sequence")
-    int sequence;
+//    TODO: The database requirements has a "Sequence" column in table "CourseRegistration".
+//    @OrderColumn(name="Sequence")
+//    @Column(name="Sequence")
+//    int sequence;
 }

--- a/src/main/java/com/cs544/project/domain/CourseRegistration.java
+++ b/src/main/java/com/cs544/project/domain/CourseRegistration.java
@@ -17,4 +17,8 @@ public class CourseRegistration {
     @ManyToOne
     @JoinColumn(name = "CourseOfferingId")
     private CourseOffering courseOffering;
+
+    @OrderColumn(name="Sequence")
+    @Column(name="Sequence")
+    int sequence;
 }

--- a/src/main/java/com/cs544/project/domain/Faculty.java
+++ b/src/main/java/com/cs544/project/domain/Faculty.java
@@ -1,6 +1,7 @@
 package com.cs544.project.domain;
 
 import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import lombok.Data;
@@ -17,5 +18,6 @@ public class Faculty extends Person {
     @CollectionTable(name = "FacultyHobby")
     List<String> hobbies;
 
+    @Column(name="Salutation")
     private String salutation;
 }

--- a/src/main/java/com/cs544/project/domain/Location.java
+++ b/src/main/java/com/cs544/project/domain/Location.java
@@ -8,9 +8,12 @@ import lombok.Data;
 public class Location {
     @Id
     @GeneratedValue
+    @Column(name="ID")
     private int id;
 
+    @Column(name = "Capacity")
     private int capacity;
+    @Column(name="Name")
     private String name;
 
     @ManyToOne

--- a/src/main/java/com/cs544/project/domain/LocationType.java
+++ b/src/main/java/com/cs544/project/domain/LocationType.java
@@ -1,9 +1,6 @@
 package com.cs544.project.domain;
 
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Data;
 
 @Data

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,8 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
+        implicit_naming_strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyHbmImpl
+        physical_naming_strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
   activemq:
     broker-url: tcp://localhost:61616
     user: admin


### PR DESCRIPTION
Here, some of the missing @Column have been added
and the physical naming strategy has been changed.
Now the database columns should look exactly like we have annotated them with 