### PR TITLE
Change generation strategy to IDENTITY

### DIFF
--- a/src/main/java/com/cs544/project/domain/AttendanceRecord.java
+++ b/src/main/java/com/cs544/project/domain/AttendanceRecord.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Entity
 public class AttendanceRecord {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
     @Column(name = "ScanDateTime")

--- a/src/main/java/com/cs544/project/domain/Course.java
+++ b/src/main/java/com/cs544/project/domain/Course.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Entity
 public class Course {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
     private float credits;

--- a/src/main/java/com/cs544/project/domain/CourseOffering.java
+++ b/src/main/java/com/cs544/project/domain/CourseOffering.java
@@ -9,7 +9,7 @@ import java.util.List;
 @Entity
 public class CourseOffering {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
     private int capacity;

--- a/src/main/java/com/cs544/project/domain/CourseRegistration.java
+++ b/src/main/java/com/cs544/project/domain/CourseRegistration.java
@@ -7,7 +7,7 @@ import lombok.Data;
 @Entity
 public class CourseRegistration {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
     @ManyToOne

--- a/src/main/java/com/cs544/project/domain/Location.java
+++ b/src/main/java/com/cs544/project/domain/Location.java
@@ -7,7 +7,8 @@ import lombok.Data;
 @Entity
 public class Location {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name="ID")
     private int id;
 
     private int capacity;

--- a/src/main/java/com/cs544/project/domain/LocationType.java
+++ b/src/main/java/com/cs544/project/domain/LocationType.java
@@ -10,7 +10,7 @@ import lombok.Data;
 @Entity
 public class LocationType {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
     private String type;

--- a/src/main/java/com/cs544/project/domain/LocationType.java
+++ b/src/main/java/com/cs544/project/domain/LocationType.java
@@ -1,9 +1,6 @@
 package com.cs544.project.domain;
 
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Data;
 
 @Data

--- a/src/main/java/com/cs544/project/domain/Person.java
+++ b/src/main/java/com/cs544/project/domain/Person.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 @SecondaryTable(name = "PersonAccount", pkJoinColumns = @PrimaryKeyJoinColumn(name = "id"))
 public class Person {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int id;
 
     private String firstName;


### PR DESCRIPTION
By default, Hibernate uses GenerationStrategy as "Sequence". This creates additional tables (followed by table_name_seq) in the database. So, to reduce clutter, let's change the generation type to IDENTITY as we have already decided on using MySQL.